### PR TITLE
maint(build): build wheels for OSX and Linux in CI

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # os: [ubuntu-20.04, windows-2019, macOS-10.15]
+        os: [ubuntu-20.04, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.10.0
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp37-* cp38-*
+          CIBW_BEFORE_ALL_LINUX: bin/cibw_before_build_linux.sh
+          CIBW_BEFORE_ALL_MACOS: bin/cibw_before_build_macosx.sh
+          # There are problems with both older and newer cython versions...
+          CIBW_BEFORE_BUILD: pip install numpy cython==0.27.3
+          CIBW_ENVIRONMENT: >
+            C_INCLUDE_PATH=$(pwd)/.local/include/
+            LIBRARY_PATH=$(pwd)/.local/lib/
+            LD_LIBRARY_PATH=$(pwd)/.local/lib:$LD_LIBRARY_PATH
+      - uses: actions/upload-artifact@v2
+        with:
+          path: wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ dist/*
 src/*.c
 doc/build/*
 fmake*
+*.whl
 MANIFEST
 .eggs
+.local

--- a/bin/build_dependencies.sh
+++ b/bin/build_dependencies.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Build local installs of python-flint's dependencies.
+# This should be run after bin/download_dependencies.sh
+#
+
+set -o errexit
+set -o xtrace
+
+# Sets variables like PREFIX and dependency versions
+source bin/build_variables.sh
+
+cd $PREFIX
+mkdir -p src
+cd src
+
+curl -O https://gmplib.org/download/gmp/gmp-$GMPVER.tar.xz
+curl -O https://www.mpfr.org/mpfr-current/mpfr-$MPFRVER.tar.gz
+curl -O https://www.flintlib.org/flint-$FLINTVER.tar.gz
+curl -O -L https://github.com/fredrik-johansson/arb/archive/refs/tags/$ARBVER.tar.gz
+mv $ARBVER.tar.gz arb-$ARBVER.tar.gz
+
+tar xf mpfr-$MPFRVER.tar.gz
+tar xf flint-$FLINTVER.tar.gz
+tar xf arb-$ARBVER.tar.gz
+tar xf gmp-$GMPVER.tar.xz
+
+cd gmp-$GMPVER
+  ./configure --prefix=$PREFIX --enable-fat --enable-shared=yes --enable-static=no
+  make -j3
+  make install
+cd ..
+
+cd mpfr-$MPFRVER
+  ./configure --prefix=$PREFIX --with-gmp=$PREFIX --enable-shared=yes --enable-static=no
+  make -j3
+  make install
+cd ..
+
+cd flint-$FLINTVER
+  ./configure --prefix=$PREFIX --with-gmp=$PREFIX --with-mpfr=$PREFIX --disable-static
+  make -j3
+  make install
+cd ..
+
+cd arb-$ARBVER
+  ./configure --prefix=$PREFIX --with-flint=$PREFIX --with-gmp=$PREFIX --with-mpfr=$PREFIX --disable-static
+  make -j3
+  make install
+cd ..
+
+
+echo
+echo -----------------------------------------------------------------------
+echo
+echo Build dependencies for python-flint compiled as shared libraries in:
+echo $PREFIX
+echo
+echo Versions:
+echo GMP: $GMPVER
+echo MPFR: $MPFRVER
+echo Flint: $FLINTVER
+echo Arb: $ARBVER
+echo
+echo -----------------------------------------------------------------------
+echo

--- a/bin/build_variables.sh
+++ b/bin/build_variables.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Create a local directory .local to be used as --prefix when building
+# local installs of python-flint's dependencies. This also sets the PREFIX
+# shell variable and environment variables giving the versions to use for each
+# dependency. This script should be sourced rather than executed e.g.:
+#
+#    $ source bin/build_variables.sh
+#
+# This is used implicitly by the other build scripts and does not need to be
+# executed directly.
+
+PREFIX=$(pwd)/.local
+mkdir -p $PREFIX
+
+GMPVER=6.2.1
+MPFRVER=4.1.0
+FLINTVER=2.7.1
+ARBVER=2.19.0

--- a/bin/build_wheel.sh
+++ b/bin/build_wheel.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Compile a python-flint wheel using the dependencies built by
+# build_dependencies.sh (which should be run first).
+
+set -o errexit
+
+PYTHONFLINTVER=0.3.0
+
+source bin/build_variables.sh
+
+python -m venv $PREFIX/venv
+source $PREFIX/venv/bin/activate
+pip install -U pip wheel delocate
+pip install numpy cython==0.27.3
+# N.B. bugs in both older and newer Cython versions...
+
+C_INCLUDE_PATH=.local/include/ LIBRARY_PATH=.local/lib/ pip wheel .
+
+wheelfinal=*.whl
+
+# On OSX bundle the dynamic libraries for the dependencies
+mkdir -p wheelhouse
+delocate-wheel -w wheelhouse $wheelfinal
+
+echo ------------------------------------------
+echo
+echo Built wheel: wheelhouse/$wheelfinal
+echo
+echo Link dependencies:
+delocate-listdeps wheelhouse/$wheelfinal
+echo
+pip install wheelhouse/$wheelfinal
+echo
+echo Demonstration:
+echo
+python -c 'import flint; print("(3/2)**2 =", flint.fmpq(3, 2)**2)'
+echo
+echo Done!
+echo
+echo ------------------------------------------

--- a/bin/cibw_before_build_linux.sh
+++ b/bin/cibw_before_build_linux.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+yum install -y xz
+bin/build_dependencies.sh

--- a/bin/cibw_before_build_macosx.sh
+++ b/bin/cibw_before_build_macosx.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bin/build_dependencies.sh


### PR DESCRIPTION
This commit adds the capability to build wheels for OSX and Linux for Python 3.7 and 3.8 in Github Actions.

The build wheels will be attached as Github Actions artifacts to this PR.