### PR TITLE
maint: update macos image for building wheels

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu-20.04, windows-2019, macOS-10.15]
-        os: [ubuntu-20.04, macOS-10.15]
+        # os: [ubuntu-20.04, windows-2019, macos-12]
+        os: [ubuntu-20.04, macos-12]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-20.04, macos-12]
         python-version: ['3.9', '3.10', '3.11']
 
     steps:


### PR DESCRIPTION
The macOS-10.15 image is deprecated. It looks like numpy uses macos-12 to build their wheels so I went with that:
https://github.com/numpy/numpy/blob/297c66131f2a32ebb7dfb0aeb9d88d917a791430/.github/workflows/wheels.yml#L78

I'll download and test the wheels before merging.