### PR TITLE
fix: use long long on Windows

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -6,6 +6,7 @@ jobs:
   build_wheels:
     name: Build wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -23,8 +24,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: cp39-* cp310-* cp311-*
-          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+          #CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+          CIBW_SKIP: "*-win32 *-musllinux_*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: bin/cibw_before_build_linux.sh
           CIBW_BEFORE_ALL_MACOS: bin/cibw_before_build_macosx.sh
           CIBW_BEFORE_BUILD: pip install numpy cython

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 build/*
 dist/*
-src/*.c
+src/flint/*.c
 doc/build/*
 fmake*
 *.whl
+*.pyc
+*.pyd
+*.so
+__pycache__
 MANIFEST
 .eggs
 .local

--- a/bin/build_inplace.sh
+++ b/bin/build_inplace.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# Build the flint._flint module in place.
+
+C_INCLUDE_PATH=.local/include/ LIBRARY_PATH=.local/lib/ python setup.py build_ext --inplace

--- a/bin/build_wheel.sh
+++ b/bin/build_wheel.sh
@@ -5,37 +5,11 @@
 
 set -o errexit
 
-PYTHONFLINTVER=0.3.0
-
 source bin/build_variables.sh
 
 python3 -m venv $PREFIX/venv
 source $PREFIX/venv/bin/activate
-pip install -U pip wheel delocate
-pip install numpy cython
-# Working as of cython==0.29.28
+pip install -U pip
+pip install numpy cython wheel
 
 C_INCLUDE_PATH=.local/include/ LIBRARY_PATH=.local/lib/ pip wheel .
-
-wheelfinal=*.whl
-
-# On OSX bundle the dynamic libraries for the dependencies
-mkdir -p wheelhouse
-delocate-wheel -w wheelhouse $wheelfinal
-
-echo ------------------------------------------
-echo
-echo Built wheel: wheelhouse/$wheelfinal
-echo
-echo Link dependencies:
-delocate-listdeps wheelhouse/$wheelfinal
-echo
-pip install wheelhouse/$wheelfinal
-echo
-echo Demonstration:
-echo
-python -c 'import flint; print("(3/2)**2 =", flint.fmpq(3, 2)**2)'
-echo
-echo Done!
-echo
-echo ------------------------------------------

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -1,7 +1,7 @@
 cdef inline int fmpz_set_pylong(fmpz_t x, obj):
     cdef int overflow
-    cdef long longval
-    longval = PyLong_AsLongAndOverflow(<PyObject*>obj, &overflow)
+    cdef slong longval
+    longval = pylong_as_slong(<PyObject*>obj, &overflow)
     if overflow:
         s = "%x" % obj
         fmpz_set_str(x, chars_from_str(s), 16)
@@ -28,7 +28,7 @@ cdef fmpz_get_intlong(fmpz_t x):
         libc.stdlib.free(s)
         return v
     else:
-        return <long>x[0]
+        return <slong>x[0]
 
 cdef int fmpz_set_any_ref(fmpz_t x, obj):
     if typecheck(obj, fmpz):


### PR DESCRIPTION
Fixes #10.

There might be more places that needs to be fixed to use `slong` rather than `long` but this is an intentionally minimal change that achieves the basic goal of getting python-flint to work on Windows. With this and #26 I was able to make a working Windows wheel that locally passed all tests.