### PR TITLE
wip: add coverage testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+plugins = Cython.Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ MANIFEST
 .eggs
 .local
 *.egg-info
+.coverage

--- a/bin/activate
+++ b/bin/activate
@@ -1,0 +1,4 @@
+export C_INCLUDE_PATH=$(pwd)/.local/include
+export LIBRARY_PATH=$(pwd)/.local/lib
+export LD_LIBRARY_PATH=$(pwd)/.local/lib
+export PYTHONPATH=$(pwd)/src

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Note: cython's Cython/Coverage.py fails for pyx files that are included in
+# other pyx files. This gives the following error:
+#
+#   $ coverage report -m
+#   Plugin 'Cython.Coverage.Plugin' did not provide a file reporter for
+#   '.../python-flint/src/flint/fmpz.pyx'.
+#
+# A patch to the file is needed:
+#
+#  --- Coverage.py.backup   2022-12-09 17:36:35.387690467 +0000
+#  +++ Coverage.py 2022-12-09 17:08:06.282516837 +0000
+#  @@ -172,7 +172,9 @@ class Plugin(CoveragePlugin):
+#          else:
+#              c_file, _ = self._find_source_files(filename)
+#              if not c_file:
+# -                return None
+# +                c_file = os.path.join(os.path.dirname(filename), 'pyflint.c')
+# +                if not os.path.exists(c_file):
+# +                    return None
+#              rel_file_path, code = self._read_source_lines(c_file, filename)
+#              if code is None:
+#                  return None  # no source found
+#
+#
+
+set -o errexit
+
+source bin/activate
+
+export PYTHON_FLINT_COVERAGE=true
+
+python setup.py build_ext --inplace
+
+coverage run test/test.py
+coverage run --append test/dtest.py
+
+coverage report -m
+coverage html


### PR DESCRIPTION
Work in progress to add coverage testing.

Currently requires a patch to cython due to the use of `include` although that wouldn't be needed if #15 was fixed.

Current coverage report:
```
$ coverage report -m
Name                      Stmts   Miss  Cover   Missing
-------------------------------------------------------
src/flint/__init__.py         1      0   100%
src/flint/acb.pyx           891    874     2%   1, 5-6, 12-40, 44-49, 53-97, 126, 129, 131-189, 196-2562
src/flint/arb.pyx           835    773     7%   1-8, 11, 17-37, 45-46, 49-50, 53-54, 57-58, 61-62, 77-78, 92, 96-101, 105-110, 117-133, 185, 187-462, 471, 474, 487-496, 503-2423
src/flint/arf.pyx           109     98    10%   28, 30, 32, 37, 39-171
src/flint/fmpq.pyx          181     89    51%   1, 38-44, 48, 53, 56, 67, 70, 78-83, 101-102, 106, 121, 148, 151, 160, 163, 172, 180-181, 185, 188, 199-331
src/flint/fmpq_mat.pyx      248    105    58%   1, 6, 62, 64-65, 71, 78-81, 86, 89, 92, 98, 101, 109, 116-120, 150, 153, 158, 170, 173, 178, 184, 191, 199, 202, 208, 211, 217, 220, 240, 251-254, 257, 264, 297-455
src/flint/fmpq_poly.pyx     234    108    54%   1, 21, 35, 71, 75, 77, 83, 86, 92, 95, 98, 114-115, 121, 127, 136, 159-172, 183, 186, 195, 198, 207, 210, 217-244, 250, 256, 263-274, 279, 294-379
src/flint/fmpz.pyx          340    177    48%   1, 11, 13-14, 18-20, 26-29, 33, 38-40, 47, 85, 88-92, 99-102, 112-118, 131, 135, 154, 292, 309-633
src/flint/fmpz_mat.pyx      268    135    50%   1, 92, 101, 108, 116, 119, 122, 128, 134, 145, 152-156, 195, 198, 213-229, 245, 262-263, 270, 280, 286-342, 358-359, 374-375, 434, 440, 442-446, 466-706
src/flint/fmpz_poly.pyx     295    162    45%   1, 10-12, 20, 32-33, 62, 67, 70, 76, 79, 135-140, 154, 157, 166, 169, 178, 190, 193, 204, 207, 218, 221, 224-227, 232, 247-505
src/flint/nmod.pyx           96     17    82%   1, 21, 42-45, 54, 63, 74-77, 95, 112, 124-127, 135, 140, 146, 156
src/flint/nmod_mat.pyx      222    100    55%   1, 8-12, 38, 42-44, 62, 64-65, 71, 77, 86, 89, 96-98, 101, 104, 107-115, 119, 149-164, 197, 200-204, 206, 218-239, 256, 264-265, 267, 269, 275-276, 279, 287, 292, 297, 310-411
src/flint/nmod_poly.pyx     199     82    59%   1, 18-20, 32, 65-69, 72, 79-84, 87, 90, 97, 107, 119-127, 133, 139-147, 161-164, 177, 181, 183, 194, 198, 200, 211, 215, 217, 230-234, 236, 238, 249-253, 255, 257, 271, 287-342
src/flint/pyflint.pyx       132     27    80%   35, 41, 95-103, 109, 113, 122-131, 142, 148-150, 190, 197, 200, 210, 220, 235, 266-267, 270, 288-293
test/test.py                436      2    99%   16, 454
-------------------------------------------------------
TOTAL                      4487   2749    39%
```
Note that that does not include files that have literally zero coverage:
```console
$ ls src/flint/*.pyx
src/flint/acb_mat.pyx     src/flint/arb_mat.pyx     src/flint/arf.pyx        src/flint/fmpq.pyx         src/flint/fmpz_poly.pyx    src/flint/nmod_mat.pyx     src/flint/pyflint.pyx
src/flint/acb_poly.pyx    src/flint/arb_poly.pyx    src/flint/dirichlet.pyx  src/flint/fmpq_series.pyx  src/flint/fmpz.pyx         src/flint/nmod_poly.pyx
src/flint/acb.pyx         src/flint/arb.pyx         src/flint/fmpq_mat.pyx   src/flint/fmpz_mat.pyx     src/flint/fmpz_series.pyx  src/flint/nmod.pyx
src/flint/acb_series.pyx  src/flint/arb_series.pyx  src/flint/fmpq_poly.pyx  src/flint/fmpz_mpoly.pyx   src/flint/functions.pyx    src/flint/nmod_series.pyx
$ ls src/flint/*.pyx | wc -l
25
$ coverage report -m | grep pyx | wc -l
13
```
