### PR TITLE
Add tests for modules wrapping flint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/*
 dist/*
 src/flint/*.c
+src/flint/*.html
 doc/build/*
 fmake*
 *.whl

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ MANIFEST
 .local
 *.egg-info
 .coverage
+*.swp

--- a/bin/activate
+++ b/bin/activate
@@ -2,3 +2,4 @@ export C_INCLUDE_PATH=$(pwd)/.local/include
 export LIBRARY_PATH=$(pwd)/.local/lib
 export LD_LIBRARY_PATH=$(pwd)/.local/lib
 export PYTHONPATH=$(pwd)/src
+source .local/venv/bin/activate

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -34,7 +34,7 @@ export PYTHON_FLINT_COVERAGE=true
 python setup.py build_ext --inplace
 
 coverage run test/test.py
-coverage run --append test/dtest.py
+#coverage run --append test/dtest.py
 
 coverage report -m
 coverage html

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -33,8 +33,8 @@ export PYTHON_FLINT_COVERAGE=true
 
 python setup.py build_ext --inplace
 
-coverage run test/test.py
+pytest --cov flint test/test.py
 #coverage run --append test/dtest.py
 
-coverage report -m
+#coverage report -m
 coverage html

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -34,7 +34,7 @@ export PYTHON_FLINT_COVERAGE=true
 python setup.py build_ext --inplace
 
 pytest --cov flint test/test.py
-#coverage run --append test/dtest.py
+coverage run --append test/dtest.py
 
 #coverage report -m
 coverage html

--- a/bin/coverage.sh
+++ b/bin/coverage.sh
@@ -34,7 +34,7 @@ export PYTHON_FLINT_COVERAGE=true
 python setup.py build_ext --inplace
 
 pytest --cov flint test/test.py
-coverage run --append test/dtest.py
+#coverage run --append test/dtest.py
 
 #coverage report -m
 coverage html

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ for e in ext_modules:
 setup(
     name='python-flint',
     cmdclass={'build_ext': build_ext},
-    ext_modules=cythonize(ext_modules, compiler_directives=compiler_directives),
+    ext_modules=cythonize(ext_modules, compiler_directives=compiler_directives, annotate=True),
     packages=['flint'],
     package_dir={'': 'src'},
     description='Bindings for FLINT and Arb',

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ for e in ext_modules:
 setup(
     name='python-flint',
     cmdclass={'build_ext': build_ext},
-    ext_modules=cythonize(ext_modules, compiler_directives=compiler_directives, annotate=True),
+    ext_modules=cythonize(ext_modules, compiler_directives=compiler_directives),
+    #ext_modules=cythonize(ext_modules, compiler_directives=compiler_directives, annotate=True),
     packages=['flint'],
     package_dir={'': 'src'},
     description='Bindings for FLINT and Arb',

--- a/src/flint/fmpq_series.pyx
+++ b/src/flint/fmpq_series.pyx
@@ -19,13 +19,6 @@ cdef fmpq_series_coerce_operands(x, y):
             return acb_series(x), acb_series(y)
     return NotImplemented, NotImplemented
 
-cdef any_as_fmpq_series(obj):
-    if typecheck(obj, fmpq_series):
-        return obj
-    if typecheck(obj, fmpz_series):
-        return fmpq_series(obj)
-    return NotImplemented
-
 cdef class fmpq_series(flint_series):
 
     cdef fmpq_poly_t val
@@ -69,21 +62,13 @@ cdef class fmpq_series(flint_series):
                 raise ZeroDivisionError("cannot create fmpq_series with zero denominator")
             fmpq_poly_scalar_div_fmpz(self.val, self.val, (<fmpz>den).val)
 
-    def __richcmp__(s, t, int op):
+    def _equal_repr(s, t):
         cdef bint r
-        if op != 2 and op != 3:
-            raise TypeError("series cannot be ordered")
-        s = any_as_fmpq_series(s)
-        if t is NotImplemented:
-            return s
-        t = any_as_fmpq_series(t)
-        if t is NotImplemented:
-            return t
+        if not typecheck(t, fmpq_series):
+            return False
         r = fmpq_poly_equal((<fmpq_series>s).val, (<fmpq_series>t).val)
         if r:
             r = (<fmpq_series>s).prec == (<fmpq_series>t).prec
-        if op == 3:
-            r = not r
         return r
 
     def __len__(self):

--- a/src/flint/fmpz_series.pyx
+++ b/src/flint/fmpz_series.pyx
@@ -68,17 +68,13 @@ cdef class fmpz_series(flint_series):
                 fmpz_poly_set_list(self.val, [val])
         fmpz_poly_truncate(self.val, max(0, self.prec))
 
-    def __richcmp__(self, other, int op):
+    def _equal_repr(self, other):
         cdef bint r
-        if op != 2 and op != 3:
-            raise TypeError("series cannot be ordered")
-        if not (typecheck(self, fmpz_series) and typecheck(other, fmpz_series)):
-            return NotImplemented
+        if not typecheck(other, fmpz_series):
+            return False
         r = fmpz_poly_equal((<fmpz_series>self).val, (<fmpz_series>other).val)
         if r:
             r = (<fmpz_series>self).prec == (<fmpz_series>other).prec
-        if op == 3:
-            r = not r
         return r
 
     def __len__(self):

--- a/src/flint/fmpz_series.pyx
+++ b/src/flint/fmpz_series.pyx
@@ -68,6 +68,19 @@ cdef class fmpz_series(flint_series):
                 fmpz_poly_set_list(self.val, [val])
         fmpz_poly_truncate(self.val, max(0, self.prec))
 
+    def __richcmp__(self, other, int op):
+        cdef bint r
+        if op != 2 and op != 3:
+            raise TypeError("series cannot be ordered")
+        if not (typecheck(self, fmpz_series) and typecheck(other, fmpz_series)):
+            return NotImplemented
+        r = fmpz_poly_equal((<fmpz_series>self).val, (<fmpz_series>other).val)
+        if r:
+            r = (<fmpz_series>self).prec == (<fmpz_series>other).prec
+        if op == 3:
+            r = not r
+        return r
+
     def __len__(self):
         return fmpz_poly_length(self.val)
 

--- a/test/test.py
+++ b/test/test.py
@@ -58,10 +58,8 @@ def test_pyflint():
         f1 = flint.fmpz_series([1,1])
         ctx.cap = 5
         f2 = flint.fmpz_series([1,1])
-        assert f1 == flint.fmpz_series([1,1],10)
-        assert f2 == flint.fmpz_series([1,1],5)
-        assert f1 != flint.fmpz_series([1,1],5)
-        assert f2 != flint.fmpz_series([1,1],10)
+        assert f1._equal_repr(flint.fmpz_series([1,1],10))
+        assert f2._equal_repr(flint.fmpz_series([1,1],5))
     finally:
         ctx.cap = oldcap
 
@@ -531,33 +529,21 @@ def test_fmpz_series():
     s3 = Z([1,1])
     s4 = Z([1,2],11)
     p1 = Zp([1,2])
-    assert (s1 == s2) is True
-    assert (s1 != s2) is False
-    assert (s1 == s3) is False
-    assert (s1 != s3) is True
-    assert (s1 == s4) is False
-    assert (s1 != s4) is True
-    assert (s1 == p1) is False
-    assert (s1 != p1) is True
-    assert (Z([1]) == flint.fmpz(1)) is False
-    assert (Z([1]) != flint.fmpz(1)) is True
-    assert (Z([1]) == 1) is False
-    assert (Z([1]) != 1) is True
-    # XXX: These are invalid power series. Should they compare "equal"?
-    assert (Z([],-1) == Z([],-1)) is True
-    assert (Z([],-1) != Z([],-1)) is False
-    assert (Z([],-2) == Z([],-1)) is True
-    assert (Z([],-2) != Z([],-1)) is False
-    assert (Z([],-1) == Z([],-2)) is True
-    assert (Z([],-1) != Z([],-2)) is False
+    assert s1._equal_repr(s1) is True
+    assert s1._equal_repr(s2) is True
+    assert s1._equal_repr(s3) is False
+    assert s1._equal_repr(s4) is False
+    assert s1._equal_repr(p1) is False
+    assert s1._equal_repr(flint.fmpz(1)) is False
+    assert s1._equal_repr(1) is False
+    assert Z([])._equal_repr(Z([0])) is True
+    assert Z([1])._equal_repr(Z([0])) is False
     # XXX: this gives a core dump:
     # s = Z([1,2])
     # s[10**10] = 1
-    assert Z([]) == Z([0])
-    assert Z([1]) != Z([0])
-    assert Z(Z([1])) == Z([1])
-    assert Z(Zp([1])) == Z([1])
-    assert Z(1) == Z([1])
+    assert Z(Z([1]))._equal_repr(Z([1]))
+    assert Z(Zp([1]))._equal_repr(Z([1]))
+    assert Z(1)._equal_repr(Z([1]))
     assert raises(lambda: Z([1]) < Z([1]), TypeError)
     assert len(Z([1,2])) == 2
     assert Z([1,2]).length() == 2
@@ -569,7 +555,7 @@ def test_fmpz_series():
     assert s5[100] == 0
     s5[2] = -1
     assert s5[2] == -1
-    assert s5 == Z([1,2,-1])
+    assert s5._equal_repr(Z([1,2,-1]))
     def set_bad():
         s5[-1] = 3
     assert raises(set_bad, ValueError)
@@ -577,48 +563,48 @@ def test_fmpz_series():
     assert Z([1,2,0,4]).repr() == "fmpz_series([1, 2, 0, 4], prec=10)"
     assert Z([],0).str() == "O(x^0)"
     assert Z([],-1).str() == "(invalid power series)"
-    assert +Z([1,2]) == Z([1,2])
-    assert -Z([1,2]) == Z([-1,-2])
-    assert Z([1,2]) + Z([3,4,5]) == Z([4,6,5])
-    assert Z([1,2]) + 1 == Z([2,2])
-    assert Z([1,2]) + Zp([3,4,5]) == Z([4,6,5])
-    assert 1 + Z([1,2]) == Z([2,2])
-    assert Zp([1,2]) + Z([3,4,5]) == Z([4,6,5])
+    assert (+Z([1,2]))._equal_repr(Z([1,2]))
+    assert (-Z([1,2]))._equal_repr(Z([-1,-2]))
+    assert (Z([1,2]) + Z([3,4,5]))._equal_repr(Z([4,6,5]))
+    assert (Z([1,2]) + 1)._equal_repr(Z([2,2]))
+    assert (Z([1,2]) + Zp([3,4,5]))._equal_repr(Z([4,6,5]))
+    assert (1 + Z([1,2]))._equal_repr(Z([2,2]))
+    assert (Zp([1,2]) + Z([3,4,5]))._equal_repr(Z([4,6,5]))
     assert raises(lambda: Z([1,2]) + [], TypeError)
     assert raises(lambda: [] + Z([1,2]), TypeError)
-    assert Z([1,2]) - Z([3,5]) == Z([-2,-3])
-    assert Z([1,2]) - 1 == Z([0,2])
-    assert 1 - Z([1,2]) == Z([0,-2])
+    assert (Z([1,2]) - Z([3,5]))._equal_repr(Z([-2,-3]))
+    assert (Z([1,2]) - 1)._equal_repr(Z([0,2]))
+    assert (1 - Z([1,2]))._equal_repr(Z([0,-2]))
     assert raises(lambda: [] - Z([1,2]), TypeError)
     assert raises(lambda: Z([1,2]) - [], TypeError)
-    assert Z([1,2]) * Z([1,2]) == Z([1,4,4])
-    assert 2 * Z([1,2]) == Z([2,4])
-    assert Z([1,2]) * 2 == Z([2,4])
+    assert (Z([1,2]) * Z([1,2]))._equal_repr(Z([1,4,4]))
+    assert (2 * Z([1,2]))._equal_repr(Z([2,4]))
+    assert (Z([1,2]) * 2)._equal_repr(Z([2,4]))
     assert raises(lambda: [] * Z([1,2]), TypeError)
     assert raises(lambda: Z([1,2]) * [], TypeError)
     assert Z([1,2]).valuation() == 0
     assert Z([0,2]).valuation() == 1
     assert Z([0,0]).valuation() == -1
-    assert Z([1,1]) / Z([1,-1]) == Z([1,2,2,2,2,2,2,2,2,2])
+    assert (Z([1,1]) / Z([1,-1]))._equal_repr(Z([1,2,2,2,2,2,2,2,2,2]))
     assert raises(lambda: Z([1,1]) / Z([]), ZeroDivisionError)
-    assert Z([]) / Z([1,-1]) == Z([])
+    assert (Z([]) / Z([1,-1]))._equal_repr(Z([]))
     # quotient would not be a power series
     assert raises(lambda: Z([1,1]) / Z([0,1]), ValueError)
     # leading term in denominator is not a unit
     assert raises(lambda: Z([1,1]) / Z([2,1]), ValueError)
-    assert Z([0,1,1]) / Z([0,1,-1]) == Z([1,2,2,2,2,2,2,2,2],9)
+    assert (Z([0,1,1]) / Z([0,1,-1]))._equal_repr(Z([1,2,2,2,2,2,2,2,2],9))
     # XXX: This gives leading term not a unit:
     # assert Z([2,4]) / 2 == Z([1,2])
-    assert Z([1,1]) / -1 == Z([-1,-1])
+    assert (Z([1,1]) / -1)._equal_repr(Z([-1,-1]))
     assert raises(lambda: Z([1,1]) / [], TypeError)
     assert raises(lambda: [] / Z([1,1]), TypeError)
-    assert Z([1,2]) ** 2 == Z([1,4,4])
+    assert (Z([1,2]) ** 2)._equal_repr(Z([1,4,4]))
     assert raises(lambda: pow(Z([1,2]), 3, 5), NotImplementedError)
-    assert Z([1,2])(Z([0,1,2])) == Z([1,2,4])
+    assert (Z([1,2])(Z([0,1,2])))._equal_repr(Z([1,2,4]))
     assert raises(lambda: Z([1,2])(Z([1,2])), ValueError)
     assert raises(lambda: Z([1,2])([]), TypeError)
     coeffs = [0, 1, -2, 8, -40, 224, -1344, 8448, -54912, 366080]
-    assert Z([0,1,2]).reversion() == Z(coeffs)
+    assert Z([0,1,2]).reversion()._equal_repr(Z(coeffs))
     # power series reversion must have valuation 1
     assert raises(lambda: Z([1,1]).reversion(), ValueError)
     # leading term is not a unit
@@ -999,45 +985,30 @@ def test_fmpq_series():
     sz1 = Z([1,2])
     sz2 = Z([1,1])
     sz3 = Z([1,1],11)
-    assert (s1 == s2) is True
-    assert (s1 != s2) is False
-    assert (s1 == s3) is False
-    assert (s1 != s3) is True
-    assert (s1 == s4) is False
-    assert (s1 != s4) is True
-    assert (s1 == p1) is False
-    assert (s1 != p1) is True
-    assert (s1 == sz1) is True
-    assert (s1 != sz1) is False
-    assert (s1 == sz2) is False
-    assert (s1 != sz2) is True
-    assert (s1 == sz3) is False
-    assert (s1 != sz3) is True
-    assert (Q([1]) == flint.fmpq(1)) is False
-    assert (Q([1]) != flint.fmpq(1)) is True
-    assert (Q([1]) == 1) is False
-    assert (Q([1]) != 1) is True
-    # XXX: These are invalid power series. Should they compare "equal"?
-    assert (Q([],-1) == Q([],-1)) is True
-    assert (Q([],-1) != Q([],-1)) is False
-    assert (Q([],-2) == Q([],-1)) is True
-    assert (Q([],-2) != Q([],-1)) is False
-    assert (Q([],-1) == Q([],-2)) is True
-    assert (Q([],-1) != Q([],-2)) is False
+    assert s1._equal_repr(s1) is True
+    assert s1._equal_repr(s2) is True
+    assert s1._equal_repr(s3) is False
+    assert s1._equal_repr(s4) is False
+    assert s1._equal_repr(p1) is False
+    assert s1._equal_repr(sz1) is False
+    assert s1._equal_repr(sz2) is False
+    assert s1._equal_repr(sz3) is False
+    assert Q([1])._equal_repr(flint.fmpq(1)) is False
+    assert Q([1])._equal_repr(1) is False
     # XXX: this gives a core dump:
     # s = Q([1,2])
     # s[10**10] = 1
-    assert Q([]) == Q([0])
-    assert Q([1]) != Q([0])
-    assert Q(Q([1])) == Q([1])
-    assert Q(Qp([1])) == Q([1])
-    assert Q(Zp([1])) == Q([1])
-    assert Q(Z([1])) == Q([1])
-    assert Q(1) == Q([1])
-    assert Q([1],1) == Q([1])
-    assert Q([1],2) == Q([flint.fmpq(1,2)])
-    assert Q([1],1,10) != Q([1],1,11)
-    assert Q([1,2],3) == Q([flint.fmpq(1,3), flint.fmpq(2,3)])
+    assert Q([])._equal_repr(Q([0]))
+    assert not Q([1])._equal_repr(Q([0]))
+    assert Q(Q([1]))._equal_repr(Q([1]))
+    assert Q(Qp([1]))._equal_repr(Q([1]))
+    assert Q(Zp([1]))._equal_repr(Q([1]))
+    assert Q(Z([1]))._equal_repr(Q([1]))
+    assert Q(1)._equal_repr(Q([1]))
+    assert Q([1],1)._equal_repr(Q([1]))
+    assert Q([1],2)._equal_repr(Q([flint.fmpq(1,2)]))
+    assert not Q([1],1,10)._equal_repr(Q([1],1,11))
+    assert Q([1,2],3)._equal_repr(Q([flint.fmpq(1,3), flint.fmpq(2,3)]))
     assert raises(lambda: Q([1],[]), TypeError)
     assert raises(lambda: Q([1],0), ZeroDivisionError)
     assert raises(lambda: Q([1]) < Q([1]), TypeError)
@@ -1051,7 +1022,7 @@ def test_fmpq_series():
     assert s5[100] == 0
     s5[2] = -1
     assert s5[2] == -1
-    assert s5 == Q([1,2,-1])
+    assert s5._equal_repr(Q([1,2,-1]))
     def set_bad():
         s5[-1] = 3
     assert raises(set_bad, ValueError)
@@ -1061,83 +1032,83 @@ def test_fmpq_series():
     assert Q([1,2,0,4]).repr() == "fmpq_series([1, 2, 0, 4], 1, prec=10)"
     assert Q([],1,0).str() == "O(x^0)"
     assert Q([],1,-1).str() == "(invalid power series)"
-    assert +Q([1,2]) == Q([1,2])
-    assert -Q([1,2]) == Q([-1,-2])
-    assert Q([1,2]) + Q([3,4,5]) == Q([4,6,5])
-    assert Q([1,2]) + 1 == Q([2,2])
-    assert Q([1,2]) + Qp([3,4,5]) == Q([4,6,5])
-    assert 1 + Q([1,2]) == Q([2,2])
-    assert Qp([1,2]) + Q([3,4,5]) == Q([4,6,5])
+    assert (+Q([1,2]))._equal_repr(Q([1,2]))
+    assert (-Q([1,2]))._equal_repr(Q([-1,-2]))
+    assert (Q([1,2]) + Q([3,4,5]))._equal_repr(Q([4,6,5]))
+    assert (Q([1,2]) + 1)._equal_repr(Q([2,2]))
+    assert (Q([1,2]) + Qp([3,4,5]))._equal_repr(Q([4,6,5]))
+    assert (1 + Q([1,2]))._equal_repr(Q([2,2]))
+    assert (Qp([1,2]) + Q([3,4,5]))._equal_repr(Q([4,6,5]))
     assert raises(lambda: Q([1,2]) + [], TypeError)
     assert raises(lambda: [] + Q([1,2]), TypeError)
-    assert Q([1,2]) - Q([3,5]) == Q([-2,-3])
-    assert Q([1,2]) - 1 == Q([0,2])
-    assert 1 - Q([1,2]) == Q([0,-2])
+    assert (Q([1,2]) - Q([3,5]))._equal_repr(Q([-2,-3]))
+    assert (Q([1,2]) - 1)._equal_repr(Q([0,2]))
+    assert (1 - Q([1,2]))._equal_repr(Q([0,-2]))
     assert raises(lambda: [] - Q([1,2]), TypeError)
     assert raises(lambda: Q([1,2]) - [], TypeError)
-    assert Q([1,2]) * Q([1,2]) == Q([1,4,4])
-    assert 2 * Q([1,2]) == Q([2,4])
-    assert Q([1,2]) * 2 == Q([2,4])
+    assert (Q([1,2]) * Q([1,2]))._equal_repr(Q([1,4,4]))
+    assert (2 * Q([1,2]))._equal_repr(Q([2,4]))
+    assert (Q([1,2]) * 2)._equal_repr(Q([2,4]))
     assert raises(lambda: [] * Q([1,2]), TypeError)
     assert raises(lambda: Q([1,2]) * [], TypeError)
     assert Q([1,2]).valuation() == 0
     assert Q([0,2]).valuation() == 1
     assert Q([0,0]).valuation() == -1
-    assert Q([1,1]) / Q([1,-1]) == Q([1,2,2,2,2,2,2,2,2,2])
+    assert (Q([1,1]) / Q([1,-1]))._equal_repr(Q([1,2,2,2,2,2,2,2,2,2]))
     assert raises(lambda: Q([1,1]) / Q([]), ZeroDivisionError)
-    assert Q([],1) / Q([1,-1]) == Q([],1)
+    assert (Q([],1) / Q([1,-1]))._equal_repr(Q([],1))
     # quotient would not be a power series
     assert raises(lambda: Q([1,1]) / Q([0,1]), ValueError)
-    assert Q([1,1]) / Q([2,1]) == Q([512, 256, -128, 64, -32, 16, -8, 4, -2, 1], 1024)
-    assert Q([0,1,1]) / Q([0,1,-1]) == Q([1,2,2,2,2,2,2,2,2],1,9)
-    assert Q([2,4]) / 2 == Q([1,2])
-    assert Q([1,4]) / 2 == Q([1,4],2)
-    assert Q([1,1]) / -1 == Q([-1,-1])
+    assert (Q([1,1]) / Q([2,1]))._equal_repr(Q([512, 256, -128, 64, -32, 16, -8, 4, -2, 1], 1024))
+    assert (Q([0,1,1]) / Q([0,1,-1]))._equal_repr(Q([1,2,2,2,2,2,2,2,2],1,9))
+    assert (Q([2,4]) / 2)._equal_repr(Q([1,2]))
+    assert (Q([1,4]) / 2)._equal_repr(Q([1,4],2))
+    assert (Q([1,1]) / -1)._equal_repr(Q([-1,-1]))
     assert raises(lambda: Q([1,1]) / [], TypeError)
     assert raises(lambda: [] / Q([1,1]), TypeError)
     q = Q([1,2],3)
-    assert q ** 0 == Q([1])
-    assert q ** 1 == q
-    assert q ** 2 == Q([1,4,4],9)
-    assert q ** 3 == Q([1,6,12,8],27)
-    assert q ** 4 == Q([1, 8, 24, 32, 16], 81)
-    assert Q([1,2]) ** 2 == Q([1,4,4])
-    assert Q([1,2]) ** 2 == Q([1,4,4])
+    assert (q ** 0)._equal_repr(Q([1]))
+    assert (q ** 1)._equal_repr(q)
+    assert (q ** 2)._equal_repr(Q([1,4,4],9))
+    assert (q ** 3)._equal_repr(Q([1,6,12,8],27))
+    assert (q ** 4)._equal_repr(Q([1, 8, 24, 32, 16], 81))
+    assert (Q([1,2]) ** 2)._equal_repr(Q([1,4,4]))
+    assert (Q([1,2]) ** 2)._equal_repr(Q([1,4,4]))
     assert raises(lambda: pow(Q([1,2]), 3, 5), NotImplementedError)
-    assert Q([1,2])(Q([0,1,2])) == Q([1,2,4])
+    assert (Q([1,2])(Q([0,1,2])))._equal_repr(Q([1,2,4]))
     assert raises(lambda: Q([1,2])(Q([1,2])), ValueError)
     assert raises(lambda: Q([1,2])([]), TypeError)
     coeffs = [0, 1, -2, 8, -40, 224, -1344, 8448, -54912, 366080]
-    assert Q([0,1,2]).reversion() == Q(coeffs)
+    assert Q([0,1,2]).reversion()._equal_repr(Q(coeffs))
     # power series reversion must have valuation 1
     assert raises(lambda: Q([1,1]).reversion(), ValueError)
-    assert Q([0,2,1]).reversion() == \
-        Q([0,32768,-8192,4096,-2560,1792,-1344,1056,-858,715],65536,10)
+    assert Q([0,2,1]).reversion()._equal_repr( \
+        Q([0,32768,-8192,4096,-2560,1792,-1344,1056,-858,715],65536,10))
     x = Q([0,1])
     expx = x.exp()
-    assert expx == Q([362880,362880,181440,60480,15120,3024,504,72,9,1],362880)
-    assert expx.inv() == Q([362880,-362880,181440,-60480,15120,-3024,504,-72,9,-1], 362880)
-    assert expx.derivative() == Q([40320,40320,20160,6720,1680,336,56,8,1],40320,prec=9)
-    assert Q([1,1]).integral() == Q([0,2,1],2)
-    assert expx.sqrt() == \
-        Q([185794560,92897280,23224320,3870720,483840,48384,4032,288,18,1],185794560)
-    assert expx.rsqrt() == \
-        Q([185794560,-92897280,23224320,-3870720,483840,-48384,4032,-288,18,-1],185794560)
-    assert expx.log() == x
+    assert (expx)._equal_repr(Q([362880,362880,181440,60480,15120,3024,504,72,9,1],362880))
+    assert (expx.inv())._equal_repr(Q([362880,-362880,181440,-60480,15120,-3024,504,-72,9,-1], 362880))
+    assert (expx.derivative())._equal_repr(Q([40320,40320,20160,6720,1680,336,56,8,1],40320,prec=9))
+    assert (Q([1,1]).integral())._equal_repr(Q([0,2,1],2))
+    assert (expx.sqrt())._equal_repr(\
+        Q([185794560,92897280,23224320,3870720,483840,48384,4032,288,18,1],185794560))
+    assert (expx.rsqrt())._equal_repr(\
+        Q([185794560,-92897280,23224320,-3870720,483840,-48384,4032,-288,18,-1],185794560))
+    assert (expx.log())._equal_repr(x)
     zero = Q()
     one = Q([1])
-    assert zero.exp() == one
-    assert one.log() == zero
-    assert x.atan() == Q([0,315,0,-105,0,63,0,-45,0,35],315)
-    assert x.atanh() == Q([0,315,0,105,0,63,0,45,0,35],315)
-    assert x.asin() == Q([0,40320,0,6720,0,3024,0,1800,0,1225],40320)
-    assert x.asinh() == Q([0,40320,0,-6720,0,3024,0,-1800,0,1225],40320)
-    assert x.sin() == Q([0,362880,0,-60480,0,3024,0,-72,0,1],362880)
-    assert x.cos() == Q([40320,0,-20160,0,1680,0,-56,0,1],40320)
-    assert x.tan() == Q([0,2835,0,945,0,378,0,153,0,62],2835)
-    assert x.sinh() == Q([0,362880,0,60480,0,3024,0,72,0,1],362880)
-    assert x.cosh() == Q([40320,0,20160,0,1680,0,56,0,1],40320)
-    assert x.tanh() == Q([0,2835,0,-945,0,378,0,-153,0,62],2835)
+    assert (zero.exp())._equal_repr(one)
+    assert (one.log())._equal_repr(zero)
+    assert (x.atan())._equal_repr(Q([0,315,0,-105,0,63,0,-45,0,35],315))
+    assert (x.atanh())._equal_repr(Q([0,315,0,105,0,63,0,45,0,35],315))
+    assert (x.asin())._equal_repr(Q([0,40320,0,6720,0,3024,0,1800,0,1225],40320))
+    assert (x.asinh())._equal_repr(Q([0,40320,0,-6720,0,3024,0,-1800,0,1225],40320))
+    assert (x.sin())._equal_repr(Q([0,362880,0,-60480,0,3024,0,-72,0,1],362880))
+    assert (x.cos())._equal_repr(Q([40320,0,-20160,0,1680,0,-56,0,1],40320))
+    assert (x.tan())._equal_repr(Q([0,2835,0,945,0,378,0,153,0,62],2835))
+    assert (x.sinh())._equal_repr(Q([0,362880,0,60480,0,3024,0,72,0,1],362880))
+    assert (x.cosh())._equal_repr(Q([40320,0,20160,0,1680,0,56,0,1],40320))
+    assert (x.tanh())._equal_repr(Q([0,2835,0,-945,0,378,0,-153,0,62],2835))
     # Constant term must be nonzero
     assert raises(lambda: Q([0,1]).inv(), ValueError)
     # Constant term must be 1

--- a/test/test.py
+++ b/test/test.py
@@ -506,6 +506,11 @@ def test_fmpq_poly():
     assert Q() == Q([]) == Q([0]) == Q([0,0])
     assert Q() != Q([1])
     assert Q([1]) == Q([1])
+    assert Q([1], 2) == Q([flint.fmpq(1,2)])
+    raises(lambda: Q([1,[]]), TypeError)
+    raises(lambda: Q({}), TypeError)
+    raises(lambda: Q([1], []), TypeError)
+    raises(lambda: Q([1], 0), ZeroDivisionError)
     assert bool(Q()) == False
     assert bool(Q([1])) == True
     assert Q(Q([1,2])) == Q([1,2])
@@ -514,12 +519,34 @@ def test_fmpq_poly():
     assert 3 + Q([1,2]) == Q([4,2])
     assert Q([1,2]) - 3 == Q([-2,2])
     assert 3 - Q([1,2]) == Q([2,-2])
+    assert raises(lambda: Q([1]) + [], TypeError)
+    assert raises(lambda: [] + Q([1]), TypeError)
+    assert raises(lambda: Q([1]) - [], TypeError)
+    assert raises(lambda: [] - Q([1]), TypeError)
+    assert raises(lambda: Q([1]) * [], TypeError)
+    assert raises(lambda: [] * Q([1]), TypeError)
+    assert Q([1,2,1]) // Q([1,1]) == Q([1,1])
+    assert Q([1,2,1]) % Q([1,1]) == 0
+    assert divmod(Q([1,2,1]), Q([1,1])) == (Q([1,1]), 0)
+    assert raises(lambda: Q([1,2,1]) // [], TypeError)
+    assert raises(lambda: [] // Q([1,2,1]), TypeError)
+    assert raises(lambda: Q([1,2,1]) % [], TypeError)
+    assert raises(lambda: [] % Q([1,2,1]), TypeError)
+    assert raises(lambda: divmod(Q([1,2,1]), []), TypeError)
+    assert raises(lambda: divmod([], Q([1,2,1])), TypeError)
+    assert raises(lambda: Q([1,2,1]) / 0, ZeroDivisionError)
+    assert raises(lambda: Q([1,2,1]) // 0, ZeroDivisionError)
+    assert raises(lambda: Q([1,2,1]) % 0, ZeroDivisionError)
+    assert raises(lambda: divmod(Q([1,2,1]), 0), ZeroDivisionError)
+    assert +Q([1,2]) == Q([1,2])
     assert -Q([1,2]) == Q([-1,-2])
     assert Q([flint.fmpq(1,2),1]) * 2 == Q([1,2])
     assert Q([1,2]) == Z([1,2])
     assert Z([1,2]) == Q([1,2])
     assert Q([1,2]) != Z([3,2])
     assert Z([1,2]) != Q([3,2])
+    assert Q([1,2]) != []
+    assert raises(lambda: Q([1,2]) < Q([1,2]), TypeError)
     assert Q([1,2,3])*Q([1,2]) == Q([1,4,7,6])
     assert Q([1,2,3])*Z([1,2]) == Q([1,4,7,6])
     assert Q([1,2,3]) * 3 == Q([3,6,9])
@@ -529,6 +556,7 @@ def test_fmpq_poly():
     assert raises(lambda: Q([1,2]) / Q([1,2]), TypeError)
     assert Q([1,2,3]) / flint.fmpq(2,3) == Q([1,2,3]) * flint.fmpq(3,2)
     assert Q([1,2,3]) ** 2 == Q([1,2,3]) * Q([1,2,3])
+    assert raises(lambda: pow(Q([1,2]), 3, 5), NotImplementedError)
     assert Q([1,2,flint.fmpq(1,2)]).coeffs() == [1,2,flint.fmpq(1,2)]
     assert Q().coeffs() == []
     assert Q().degree() == -1
@@ -540,18 +568,34 @@ def test_fmpq_poly():
     assert (Q([1,2,3]) / 5).numer() == (Q([1,2,3]) / 5).p == Z([1,2,3])
     assert (Q([1,2,3]) / 5).denom() == (Q([1,2,3]) / 5).q == 5
     ctx.pretty = False
+    assert repr(Q([15,20,10])) == "fmpq_poly([15, 20, 10])"
     assert repr(Q([15,20,10]) / 25) == "fmpq_poly([3, 4, 2], 5)"
     ctx.pretty = True
     assert str(Q([3,4,2],5)) == "2/5*x^2 + 4/5*x + 3/5"
     a = Q([2,2,3],4)
     assert a[2] == flint.fmpq(3,4)
+    assert a[-1] == flint.fmpq(0)
     a[2] = 4
+    def set_bad():
+        a[-1] = 2
+    raises(set_bad, ValueError)
     assert a == Q([1,1,8],2)
     p = Q([3,4,5],7)
     assert p(2) == flint.fmpq(31,7)
     assert p(flint.fmpq(2,3)) == flint.fmpq(71,63)
     assert p(Z([1,-1])) == Q([12,-14,5],7)
     assert p(flint.fmpq_poly([2,3],5)) == flint.fmpq_poly([27,24,9],7*5)
+    assert raises(lambda: p([]), TypeError)
+    assert Q([1,2,3]).derivative() == Q([2,6])
+    assert Q([1,2,3]).integral() == Q([0,1,1,1])
+    assert Q([1,2,1]).gcd(Q([1,1])) == Q([1,1])
+    assert Q([1,2,1]).xgcd(Q([1,1])) == (Q([1,1]), 0, 1)
+    assert raises(lambda: Q([1,2,1]).gcd([]), TypeError)
+    assert raises(lambda: Q([1,2,1]).xgcd([]), TypeError)
+    assert Q([1,2,1]).factor() == (1, [(Q([1,1]), 2)])
+    assert Q.bernoulli_poly(3) == Q([0,1,-3,2],2)
+    assert Q.euler_poly(3) == Q([1,0,-6,4],4)
+    assert Q.legendre_p(3) == Q([0,-3,0,5],2)
 
 def test_fmpq_mat():
     Q = flint.fmpq_mat

--- a/test/test.py
+++ b/test/test.py
@@ -52,6 +52,22 @@ def test_pyflint():
     finally:
         ctx.prec = oldprec
 
+    assert ctx.cap == 10
+    oldcap = ctx.cap
+    try:
+        f1 = flint.fmpz_series([1,1])
+        ctx.cap = 5
+        f2 = flint.fmpz_series([1,1])
+        assert f1 == flint.fmpz_series([1,1],10)
+        assert f2 == flint.fmpz_series([1,1],5)
+        assert f1 != flint.fmpz_series([1,1],5)
+        assert f2 != flint.fmpz_series([1,1],10)
+    finally:
+        ctx.cap = oldcap
+
+    assert raises(lambda: setattr(ctx, "cap", -1), ValueError)
+    assert raises(lambda: setattr(ctx, "prec", -1), ValueError)
+    assert raises(lambda: setattr(ctx, "dps", -1), ValueError)
 
 def test_fmpz():
     assert flint.fmpz() == flint.fmpz(0)
@@ -1039,6 +1055,8 @@ def test_fmpq_series():
     def set_bad():
         s5[-1] = 3
     assert raises(set_bad, ValueError)
+    assert Q([1,2,1]).coeffs() == list(Q([1,2,1])) == [1,2,1]
+    assert Q([1,2,1],2).coeffs() == [flint.fmpq(1,2),1,flint.fmpq(1,2)]
     assert Q([1,2,0,4]).str() == "1 + 2*x + 4*x^3 + O(x^10)"
     assert Q([1,2,0,4]).repr() == "fmpq_series([1, 2, 0, 4], 1, prec=10)"
     assert Q([],1,0).str() == "O(x^0)"

--- a/test/test.py
+++ b/test/test.py
@@ -15,6 +15,44 @@ def raises(f, exception):
         return True
     return False
 
+
+_default_ctx_string = """\
+pretty = True      # pretty-print repr() output
+unicode = False    # use unicode characters in output
+prec = 53          # real/complex precision (in bits)
+dps = 15           # real/complex precision (in digits)
+cap = 10           # power series precision
+threads = 1        # max number of threads used internally
+"""
+
+def test_pyflint():
+    ctx = flint.ctx
+    assert str(ctx) == repr(ctx) == _default_ctx_string
+    assert ctx.prec == 53
+    oldprec = ctx.prec
+    try:
+        f1 = flint.arb(2).sqrt()
+        ctx.prec = 10
+        f2 = flint.arb(2).sqrt()
+        assert f1.rad() < f2.rad()
+        assert 1e-17 < f1.rad() < 1e-15
+        assert 1e-3 < f2.rad() < 1e-2
+    finally:
+        ctx.prec = oldprec
+
+    assert ctx.dps == 15
+    olddps = ctx.dps
+    try:
+        f1 = flint.arb(2).sqrt()
+        ctx.dps = 3
+        f2 = flint.arb(2).sqrt()
+        assert f1.rad() < f2.rad()
+        assert 1e-17 < f1.rad() < 1e-15
+        assert 1e-4 < f2.rad() < 1e-3
+    finally:
+        ctx.prec = oldprec
+
+
 def test_fmpz():
     assert flint.fmpz() == flint.fmpz(0)
     L = [0, 1, 2, 3, 2**31-1, 2**31, 2**63-1, 2**63, 2**64-1, 2**64]
@@ -260,6 +298,10 @@ def test_fmpz_poly():
     assert repr(Z([1,2])) == "fmpz_poly([1, 2])"
     ctx.pretty = True
     assert str(Z([1,2])) == "2*x + 1"
+    assert str(Z([])) == "0"
+    assert str(Z([1,0,2])) == "2*x^2 + 1"
+    assert str(Z([-1,0,2])) == "2*x^2 + (-1)"
+    assert str(Z([-1,0,1])) == "x^2 + (-1)"
     p = Z([3,4,5])
     assert p(2) == 31
     assert p(flint.fmpq(2,3)) == flint.fmpq(71,9)

--- a/test/test.py
+++ b/test/test.py
@@ -507,10 +507,10 @@ def test_fmpq_poly():
     assert Q() != Q([1])
     assert Q([1]) == Q([1])
     assert Q([1], 2) == Q([flint.fmpq(1,2)])
-    raises(lambda: Q([1,[]]), TypeError)
-    raises(lambda: Q({}), TypeError)
-    raises(lambda: Q([1], []), TypeError)
-    raises(lambda: Q([1], 0), ZeroDivisionError)
+    assert raises(lambda: Q([1,[]]), TypeError)
+    assert raises(lambda: Q({}), TypeError)
+    assert raises(lambda: Q([1], []), TypeError)
+    assert raises(lambda: Q([1], 0), ZeroDivisionError)
     assert bool(Q()) == False
     assert bool(Q([1])) == True
     assert Q(Q([1,2])) == Q([1,2])
@@ -578,7 +578,7 @@ def test_fmpq_poly():
     a[2] = 4
     def set_bad():
         a[-1] = 2
-    raises(set_bad, ValueError)
+    assert raises(set_bad, ValueError)
     assert a == Q([1,1,8],2)
     p = Q([3,4,5],7)
     assert p(2) == flint.fmpq(31,7)

--- a/test/test.py
+++ b/test/test.py
@@ -639,11 +639,15 @@ def test_nmod():
     assert G(1,2) != G(0,2)
     assert G(0,2) != G(0,3)
     assert G(3,5) == G(8,5)
+    assert raises(lambda: G([], 3), TypeError)
     #assert G(3,5) == 8        # do we want this?
     #assert 8 == G(3,5)
     assert G(3,5) != 7
     assert 7 != G(3,5)
-    assert G(-3,5) == -G(3,5) == G(2,5)
+    assert raises(lambda: G(3,5) < G(2,5), TypeError)
+    assert bool(G(0,5)) is False
+    assert bool(G(2,5)) is True
+    assert G(-3,5) == -G(3,5) == G(2,5) == +G(2,5)
     assert G(2,5) + G(1,5) == G(3,5)
     assert G(2,5) + 1 == G(3,5)
     assert 1 + G(2,5) == G(3,5)
@@ -658,13 +662,25 @@ def test_nmod():
     assert 3 / G(2,17) == G(10,17)
     assert G(3,17) * flint.fmpq(11,5) == G(10,17)
     assert G(3,17) / flint.fmpq(11,5) == G(6,17)
+    assert G(flint.fmpq(2, 3), 5) == G(4,5)
+    assert raises(lambda: G(flint.fmpq(2, 3), 3), ZeroDivisionError)
     assert raises(lambda: G(2,5) / G(0,5), ZeroDivisionError)
     assert raises(lambda: G(2,5) / 0, ZeroDivisionError)
     assert raises(lambda: G(2,5) + G(2,7), ValueError)
     assert raises(lambda: G(2,5) - G(2,7), ValueError)
     assert raises(lambda: G(2,5) * G(2,7), ValueError)
     assert raises(lambda: G(2,5) / G(2,7), ValueError)
+    assert raises(lambda: G(2,5) + [], TypeError)
+    assert raises(lambda: G(2,5) - [], TypeError)
+    assert raises(lambda: G(2,5) * [], TypeError)
+    assert raises(lambda: G(2,5) / [], TypeError)
+    assert raises(lambda: [] + G(2,5), TypeError)
+    assert raises(lambda: [] - G(2,5), TypeError)
+    assert raises(lambda: [] * G(2,5), TypeError)
+    assert raises(lambda: [] / G(2,5), TypeError)
     assert G(3,17).modulus() == 17
+    assert str(G(3,5)) == "3"
+    assert G(3,5).repr() == "nmod(3, 5)"
 
 def test_nmod_poly():
     P = flint.nmod_poly

--- a/test/test.py
+++ b/test/test.py
@@ -981,8 +981,13 @@ def test_arb():
     assert not (A("1.1") == A("1.1"))
 
 if __name__ == "__main__":
+    sys.stdout.write("test_pyflint..."); test_pyflint(); print("OK")
     sys.stdout.write("test_fmpz..."); test_fmpz(); print("OK")
+    sys.stdout.write("test_fmpz_factor..."); test_fmpz_factor(); print("OK")
+    sys.stdout.write("test_fmpz_functions..."); test_fmpz_functions(); print("OK")
     sys.stdout.write("test_fmpz_poly..."); test_fmpz_poly(); print("OK")
+    sys.stdout.write("test_fmpz_poly_factor..."); test_fmpz_poly_factor(); print("OK")
+    sys.stdout.write("test_fmpz_poly_functions..."); test_fmpz_poly_functions(); print("OK")
     sys.stdout.write("test_fmpz_mat..."); test_fmpz_mat(); print("OK")
     sys.stdout.write("test_fmpq..."); test_fmpq(); print("OK")
     sys.stdout.write("test_fmpq_poly..."); test_fmpq_poly(); print("OK")
@@ -992,13 +997,3 @@ if __name__ == "__main__":
     sys.stdout.write("test_nmod_mat..."); test_nmod_mat(); print("OK")
     sys.stdout.write("test_arb.."); test_arb(); print("OK")
     print("OK")
-    #
-    # The doctests currently fail on Windows so for now we separate them into a
-    # separate test/doctest.py.
-    #
-    #sys.stdout.write("doctests...");
-    #fail, total = doctest.testmod(flint._flint);
-    #if fail == 0:
-    #    print("OK")
-    #else:
-    #    raise AssertionError("%i of %i doctests failed" % (fail, total))

--- a/test/test.py
+++ b/test/test.py
@@ -317,6 +317,11 @@ def test_fmpz_poly():
     assert Z([1,2,2]).sqrt() is None
     assert Z([1,0,2,0,3]).deflation() == (Z([1,2,3]), 2)
     assert Z([1,1]).deflation() == (Z([1,1]), 1)
+    [(r,m)] = Z([1,1]).roots()
+    assert m == 1
+    assert r.overlaps(-1)
+    assert Z([]).roots() == []
+    assert Z([1]).roots() == []
 
 def test_fmpz_poly_factor():
     Z = flint.fmpz_poly
@@ -498,6 +503,11 @@ def test_fmpz_mat():
     M6 = M([[2,0,0],[0,2,1],[0,0,2]])
     assert M6.charpoly() == flint.fmpz_poly([-8,12,-6,1])
     assert M6.minpoly() == flint.fmpz_poly([4,-4,1])
+    assert list(M6) == [2,0,0,0,2,1,0,0,2]
+
+def test_fmpz_series():
+    Z = flint.fmpz_series
+    Z([1,2])
 
 def test_fmpq():
     Q = flint.fmpq
@@ -643,8 +653,6 @@ def test_fmpq():
             else:
                 assert func(n) == val
 
-
-
 def test_fmpq_poly():
     Q = flint.fmpq_poly
     Z = flint.fmpz_poly
@@ -741,6 +749,11 @@ def test_fmpq_poly():
     assert Q.bernoulli_poly(3) == Q([0,1,-3,2],2)
     assert Q.euler_poly(3) == Q([1,0,-6,4],4)
     assert Q.legendre_p(3) == Q([0,-3,0,5],2)
+    assert Q([]).roots() == []
+    assert Q([1]).roots() == []
+    [(r,m)] = Q([1,1]).roots()
+    assert m == 1
+    assert r.overlaps(-1)
 
 def test_fmpq_mat():
     Q = flint.fmpq_mat
@@ -854,6 +867,10 @@ def test_fmpq_mat():
     M3 = Q([[half,0,0],[0,half,1],[0,0,half]])
     assert M3.charpoly() == flint.fmpq_poly([-1,6,-12,8]) / 8
     assert M3.minpoly() == flint.fmpq_poly([1,-4,4]) / 4
+
+def test_fmpq_series():
+    Z = flint.fmpq_series
+    Z([1,2])
 
 def test_nmod():
     G = flint.nmod
@@ -1123,6 +1140,10 @@ def test_nmod_mat():
     M6 = M6_copy
     assert M6.nullspace() == (M([[1,15,1],[0,0,0],[0,0,0]],17).transpose(), 1)
 
+def test_nmod_series():
+    # XXX: currently no code in nmod_series.pyx
+    pass
+
 def test_arb():
     A = flint.arb
     assert A(3) > A(2.5)
@@ -1142,9 +1163,11 @@ if __name__ == "__main__":
     sys.stdout.write("test_fmpz_poly_factor..."); test_fmpz_poly_factor(); print("OK")
     sys.stdout.write("test_fmpz_poly_functions..."); test_fmpz_poly_functions(); print("OK")
     sys.stdout.write("test_fmpz_mat..."); test_fmpz_mat(); print("OK")
+    sys.stdout.write("test_fmpz_series..."); test_fmpz_series(); print("OK")
     sys.stdout.write("test_fmpq..."); test_fmpq(); print("OK")
     sys.stdout.write("test_fmpq_poly..."); test_fmpq_poly(); print("OK")
     sys.stdout.write("test_fmpq_mat..."); test_fmpq_mat(); print("OK")
+    sys.stdout.write("test_fmpq_series..."); test_fmpq_series(); print("OK")
     sys.stdout.write("test_nmod..."); test_nmod(); print("OK")
     sys.stdout.write("test_nmod_poly..."); test_nmod_poly(); print("OK")
     sys.stdout.write("test_nmod_mat..."); test_nmod_mat(); print("OK")

--- a/test/test.py
+++ b/test/test.py
@@ -683,23 +683,35 @@ def test_nmod():
     assert G(3,5).repr() == "nmod(3, 5)"
 
 def test_nmod_poly():
+    N = flint.nmod
     P = flint.nmod_poly
     Z = flint.fmpz_poly
     assert P([],17) == P([0],17)
     assert P([1,2,3],17) == P([1,2,3],17)
     assert P([1,2,3],17) != P([1,2,3],15)
     assert P([1,2,3],17) != P([1,2,4],15)
+    assert P([1,2,3],17) != 1
+    assert P([1,2,3],17) != Z([1,2,3])
+    assert raises(lambda: P([1,2],3) < P([1,2],3), TypeError)
     assert P(Z([1,2,3]),17) == P([1,2,3],17)
-    assert P([1,2,flint.nmod(3,17)],17) == P([1,2,3],17)
+    assert P([1,2,N(3,17)],17) == P([1,2,3],17)
+    assert P(P([1,2],17),17) == P([1,2],17)
+    assert raises(lambda: P(P([1,2],17),13), ValueError)
+    assert raises(lambda: P([1,2,[]],17), TypeError)
     assert raises(lambda: P([1,2,flint.nmod(3,15)],17), ValueError)
+    assert raises(lambda: P([1,2],0), ValueError)
+    assert raises(lambda: P({},3), TypeError)
     assert P([1,2,3],17).degree() == 2
     assert P([1,2,3],17).length() == 3
+    assert len(P([1,2,3],17)) == 3
+    assert P([1,2,3],5).coeffs() == [N(1,5),N(2,5),N(3,5)]
     assert P([1,2,3],17) + 2 == P([3,2,3],17)
     assert 2 + P([1,2,3],17) == P([3,2,3],17)
     assert P([1,2,3],17) + P([3,4,5],17) == P([4,6,8],17)
     assert P([1,2,3],17) + P([3,4,5],17) == P([4,6,8],17)
     assert P([1,2,3],17) - 2 == P([16,2,3],17)
     assert 2 - P([1,2,3],17) == -P([16,2,3],17)
+    assert +P([1,2,3],17) == P([1,2,3],17)
     assert P([1,2,3],17) - P([3,4,6],17) == P([15,15,14],17)
     assert P([1,2,3],17) * 2 == P([2,4,6],17)
     assert 2 * P([1,2,3],17) == P([2,4,6],17)
@@ -708,12 +720,65 @@ def test_nmod_poly():
     assert Z([1,2,3]) * P([1,2,3],17) == P([1,4,10,12,9], 17)
     assert P([1,2,3,4,5],17) % P([2,3,4],17) == P([12,12],17)
     assert P([1,2,3,4,5],17) // P([2,3,4],17) == P([3,16,14],17)
+    assert raises(lambda: P([1,2],5) // P([],5), ZeroDivisionError)
+    assert raises(lambda: P([1,2],5) % P([],5), ZeroDivisionError)
+    assert raises(lambda: divmod(P([1,2],5), P([],5)), ZeroDivisionError)
     assert P([1,2,3,4,5],17) ** 2 == P([1,2,3,4,5],17) * P([1,2,3,4,5],17)
-    assert P([1,2,3],17) * flint.nmod(3,17) == P([3,6,9],17)
+    assert P([1,2,3],17) * N(3,17) == P([3,6,9],17)
+    s = P([1,2,3],17)
+    s2 = P([1,2,3],5)
+    assert raises(lambda: s + s2, ValueError)
+    assert raises(lambda: s - s2, ValueError)
+    assert raises(lambda: s * s2, ValueError)
+    assert raises(lambda: s // s2, ValueError)
+    assert raises(lambda: s % s2, ValueError)
+    assert raises(lambda: s2 + s, ValueError)
+    assert raises(lambda: s2 - s, ValueError)
+    assert raises(lambda: s2 * s, ValueError)
+    assert raises(lambda: s2 // s, ValueError)
+    assert raises(lambda: s2 % s, ValueError)
+    assert raises(lambda: s + [], TypeError)
+    assert raises(lambda: s - [], TypeError)
+    assert raises(lambda: s * [], TypeError)
+    assert raises(lambda: s // [], TypeError)
+    assert raises(lambda: s % [], TypeError)
+    assert raises(lambda: [] + s, TypeError)
+    assert raises(lambda: [] - s, TypeError)
+    assert raises(lambda: [] * s, TypeError)
+    assert raises(lambda: [] // s, TypeError)
+    assert raises(lambda: [] % s, TypeError)
+    assert raises(lambda: pow(P([1,2],3), 3, 4), NotImplementedError)
     assert str(P([1,2,3],17)) == "3*x^2 + 2*x + 1"
+    assert P([1,2,3],17).repr() == "nmod_poly([1, 2, 3], 17)"
     p = P([3,4,5],17)
-    assert p(14) == flint.nmod(2,17)
+    assert p(14) == N(2,17)
     assert p(P([1,2,3],17)) == P([12,11,11,9,11],17)
+    assert raises(lambda: p({}), TypeError)
+    p2 = P([3,4,5],17)
+    assert p2[1] == N(4,17)
+    assert p2[-1] == N(0,17)
+    p2[1] = N(2,17)
+    assert p2 == P([3,2,5],17)
+    p2[1] = 6
+    assert p2 == P([3,6,5],17)
+    def set_bad1():
+        p2[-1] = 3
+    def set_bad2():
+        p2[2] = []
+    assert raises(set_bad1, ValueError)
+    assert raises(set_bad2, TypeError)
+    assert bool(P([], 5)) is False
+    assert bool(P([1], 5)) is True
+    assert P([1,2,1],3).gcd(P([1,1],3)) == P([1,1],3)
+    raises(lambda: P([1,2],3).gcd([]), TypeError)
+    raises(lambda: P([1,2],3).gcd(P([1,2],5)), ValueError)
+    p3 = P([1,2,3,4,5,6],7)
+    f3 = (N(6,7), [(P([6, 1],7), 5)])
+    assert p3.factor() == f3
+    # XXX: factor ignores an invalid algorithm string
+    for alg in [None, 'berlekamp', 'cantor-zassenhaus']:
+        assert p3.factor(alg) == f3
+        assert p3.factor(algorithm=alg) == f3
 
 def test_nmod_mat():
     M = flint.nmod_mat

--- a/test/test.py
+++ b/test/test.py
@@ -358,6 +358,13 @@ def test_fmpz_mat():
     assert a.entries() == [1,2,3,4,5,6]
     assert a.table() == [[1,2,3],[4,5,6]]
     assert (a + b).entries() == [5,7,9,11,13,15]
+    assert (a - b).entries() == [-3,-3,-3,-3,-3,-3]
+    assert a.transpose() == M(3,2,[1,4,2,5,3,6])
+    assert raises(lambda: a + 1, TypeError)
+    assert raises(lambda: 1 + a, TypeError)
+    assert raises(lambda: a - 1, TypeError)
+    assert raises(lambda: 1 - a, TypeError)
+    # XXX: Maybe there should be a ShapeError or something?
     assert raises(a.det, ValueError)
     assert +a == a
     assert -a == M(2,3,[-1,-2,-3,-4,-5,-6])
@@ -374,7 +381,11 @@ def test_fmpz_mat():
     A = M.randbits(5,3,2)
     B = M.randtest(3,7,3)
     C = M.randtest(7,2,4)
+    assert (A.nrows(),A.ncols()) == (5,3)
+    assert (B.nrows(),B.ncols()) == (3,7)
+    assert (C.nrows(),C.ncols()) == (7,2)
     assert A*(B*C) == (A*B)*C
+    assert raises(lambda: A*C, ValueError)
     assert bool(M(2,2,[0,0,0,0])) == False
     assert bool(M(2,2,[0,0,0,1])) == True
     ctx.pretty = False
@@ -389,12 +400,57 @@ def test_fmpz_mat():
     assert raises(lambda: M.randrank(4,3,4,1), ValueError)
     assert raises(lambda: M.randrank(3,4,4,1), ValueError)
     assert M(1,1,[3]) ** 5 == M(1,1,[3**5])
+    assert raises(lambda: pow(M([[1]]), 2, 3), NotImplementedError)
     assert raises(lambda: M(1,2) ** 3, ValueError)
     assert raises(lambda: M(1,1) ** M(1,1), TypeError)
     assert raises(lambda: 1 ** M(1,1), TypeError)
     assert raises(lambda: M([1]), TypeError)
     assert raises(lambda: M([[1],[2,3]]), ValueError)
+    assert raises(lambda: M(None), TypeError)
+    assert raises(lambda: M(2,2,[1,2,3]), ValueError)
+    assert raises(lambda: M(2,2,2,2), ValueError)
     assert M([[1,2,3],[4,5,6]]) == M(2,3,[1,2,3,4,5,6])
+    assert raises(lambda: M([[1]]) < M([[2]]), TypeError)
+    assert (M([[1]]) == 1) is False
+    assert (1 == M([[1]])) is False
+    assert (M([[1]]) != 1) is True
+    assert (1 != M([[1]])) is True
+    D = M([[1,2],[3,4]])
+    assert (D[0,0],D[0,1],D[1,0],D[1,1]) == (1,2,3,4)
+    D[0,0] = 3
+    assert D == M([[3,2],[3,4]])
+    def set_bad(i,j):
+        D[i,j] = -1
+    # XXX: Should be IndexError
+    raises(lambda: set_bad(2,0), ValueError)
+    raises(lambda: set_bad(0,2), ValueError)
+    raises(lambda: D[0,2], ValueError)
+    raises(lambda: D[0,2], ValueError)
+    # XXX: Negative indices?
+    raises(lambda: set_bad(-1,0), ValueError)
+    raises(lambda: set_bad(0,-1), ValueError)
+    raises(lambda: D[-1,0], ValueError)
+    raises(lambda: D[0,-1], ValueError)
+    assert M.hadamard(2) == M([[1,1],[1,-1]])
+    assert raises(lambda: M.hadamard(3), ValueError)
+    assert M.hadamard(2).is_hadamard() is True
+    assert M([[1,2],[3,4]]).is_hadamard() is False
+    M1 = M([[1,0],[1,1]])
+    M2 = M([[1,0],[-1,1]])
+    x = M([[3],[4]])
+    b = M([[3],[7]])
+    assert M1.inv() == M2
+    assert M2.inv() == M1
+    assert M1.inv(integer=True) == M2
+    assert M2.inv(integer=True) == M1
+    assert M1*x == b
+    assert M1.solve(b) == x
+    assert M1.solve(b, integer=True) == x
+    assert raises(lambda: M([[1,2,3],[4,5,6]]).inv(), ValueError)
+    assert raises(lambda: M([[1,1],[1,1]]).inv(), ZeroDivisionError)
+    assert raises(lambda: M([[1,0],[1,2]]).inv(integer=True), ValueError)
+    half = flint.fmpq(1,2)
+    assert M([[1,0],[1,2]]).inv() == flint.fmpq_mat([[1, 0], [-half, half]])
 
 def test_fmpq():
     Q = flint.fmpq


### PR DESCRIPTION
This is a work in progress.

Maybe the test script should be reorganised a bit as the current one-test-function-per-module structure will get a bit unwieldy if more tests are added.