### PR TITLE
maint: use msys2-ucrt instead of msys2-mingw64

### DIFF
--- a/.github/workflows/buildwheel.yml
+++ b/.github/workflows/buildwheel.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: mingw64
+          msystem: ucrt64
           # path-type inherit is used so that when cibuildwheel calls msys2 to
           # run bin/cibw_before_build_windows.sh the virtual environment
           # created by cibuildwheel will be available within msys2. The


### PR DESCRIPTION
I think that linking against ucrt is preferable rather than msvcrt although currently it doesn't seem to cause any problems.

There is some information about this here:
https://www.msys2.org/docs/environments/

My understanding is that python.org builds of CPython link against ucrt from Python 3.5 onwards:
https://matthew-brett.github.io/pydagogue/python_msvc.html