### PR TITLE
Add missing operations for fmpz and fmpq

### DIFF
--- a/src/flint/_flint.pxd
+++ b/src/flint/_flint.pxd
@@ -267,6 +267,7 @@ cdef extern from "flint/fmpz.h":
     void fmpz_pow_ui(fmpz_t f,  fmpz_t g, ulong exp)
     void fmpz_powm_ui(fmpz_t f,  fmpz_t g, ulong exp,  fmpz_t m)
     void fmpz_powm(fmpz_t f,  fmpz_t g,  fmpz_t e,  fmpz_t m)
+    int fmpz_pow_fmpz(fmpz_t f, const fmpz_t g, const fmpz_t x)
     int fmpz_sqrtmod(fmpz_t b,  fmpz_t a,  fmpz_t p)
     void fmpz_sqrt(fmpz_t f,  fmpz_t g)
     void fmpz_sqrtrem(fmpz_t f, fmpz_t r,  fmpz_t g)
@@ -310,6 +311,10 @@ cdef extern from "flint/fmpz.h":
     int fmpz_jacobi(const fmpz_t a, const fmpz_t p)
     int fmpz_is_prime(const fmpz_t n)
     int fmpz_is_probabprime(const fmpz_t n)
+    void fmpz_complement(fmpz_t r, const fmpz_t f)
+    void fmpz_and(fmpz_t r, const fmpz_t a, const fmpz_t b)
+    void fmpz_or(fmpz_t r, const fmpz_t a, const fmpz_t b)
+    void fmpz_xor(fmpz_t r, const fmpz_t a, const fmpz_t b)
 
 cdef extern from "flint/fmpz_factor.h":
     ctypedef struct fmpz_factor_struct:
@@ -547,6 +552,7 @@ cdef extern from "flint/fmpq.h":
     void fmpq_div(fmpq_t res, fmpq_t op1, fmpq_t op2)
     void fmpq_div_fmpz(fmpq_t res, fmpq_t op, fmpz_t x)
     int fmpq_mod_fmpz(fmpz_t res, fmpq_t x, fmpz_t mod)
+    int fmpq_pow_fmpz(fmpq_t a, const fmpq_t b, const fmpz_t e)
     int fmpq_reconstruct_fmpz(fmpq_t res, fmpz_t a, fmpz_t m)
     int fmpq_reconstruct_fmpz_2(fmpq_t res, fmpz_t a, fmpz_t m, fmpz_t N, fmpz_t D)
     mp_bitcnt_t fmpq_height_bits(fmpq_t x)

--- a/src/flint/fmpq.pyx
+++ b/src/flint/fmpq.pyx
@@ -130,10 +130,7 @@ cdef class fmpq(flint_scalar):
             return "%s/%s" % (self.p.str(**kwargs), self.q.str(**kwargs))
 
     def __int__(self):
-        if self.p >= 0:
-            return int(self.p // self.q)
-        else:
-            return - int((-self.p) // self.q)
+        return int(self.trunc())
 
     def __floor__(self):
         return self.floor()

--- a/src/flint/fmpq.pyx
+++ b/src/flint/fmpq.pyx
@@ -105,6 +105,9 @@ cdef class fmpq(flint_scalar):
     numerator = property(numer)
     denominator = property(denom)
 
+    def __reduce__(self):
+        return (fmpq, (int(self.p), int(self.q)))
+
     def repr(self):
         if self.q == 1:
             return "fmpq(%s)" % self.p

--- a/src/flint/fmpq.pyx
+++ b/src/flint/fmpq.pyx
@@ -136,10 +136,19 @@ cdef class fmpq(flint_scalar):
             return - int((-self.p) // self.q)
 
     def __floor__(self):
-        return int(self.p // self.q)
+        return self.floor()
+
+    def __ceil__(self):
+        return self.ceil()
+
+    def __trunc__(self):
+        return self.trunc()
 
     def __nonzero__(self):
         return not fmpq_is_zero(self.val)
+
+    def __round__(self, ndigits=None):
+        return self.round(ndigits)
 
     def __pos__(self):
         return self
@@ -350,6 +359,37 @@ cdef class fmpq(flint_scalar):
         cdef fmpz r = fmpz.__new__(fmpz)
         fmpz_cdiv_q(r.val, fmpq_numref(self.val), fmpq_denref(self.val))
         return r
+
+    def trunc(self):
+        """
+        Truncation function.
+
+            >>> fmpq(3,2).trunc()
+            1
+            >>> fmpq(-3,2).trunc()
+            -1
+        """
+        cdef fmpz r = fmpz.__new__(fmpz)
+        fmpz_tdiv_q(r.val, fmpq_numref(self.val), fmpq_denref(self.val))
+        return r
+
+    def round(self, ndigits=None):
+        """
+        Rounding function.
+
+            >>> fmpq(3,2).round()
+            2
+            >>> fmpq(-3,2).round()
+            -2
+        """
+        from fractions import Fraction
+        fself = Fraction(int(self.p), int(self.q))
+        if ndigits is not None:
+            fround = round(fself, ndigits)
+            return fmpq(fround.numerator, fround.denominator)
+        else:
+            fround = round(fself)
+            return fmpz(fround)
 
     def __hash__(self):
         from fractions import Fraction

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -115,6 +115,21 @@ cdef class fmpz(flint_scalar):
     def __float__(self):
         return float(fmpz_get_intlong(self.val))
 
+    def __floor__(self):
+        return self
+
+    def __ceil__(self):
+        return self
+
+    def __trunc__(self):
+        return self
+
+    def __round__(self, ndigits=None):
+        if ndigits is None:
+            return self
+        else:
+            return fmpz(round(int(self), ndigits))
+
     def __richcmp__(s, t, int op):
         cdef bint res = 0
         cdef long tl

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -487,29 +487,45 @@ cdef class fmpz(flint_scalar):
             fmpz_clear(tval)
         return u
 
+    # This is the correct code when fmpz_or is fixed (in flint 3.0.0)
+    #
+    #def __or__(self, other):
+    #    cdef fmpz_struct tval[1]
+    #    cdef int ttype = FMPZ_UNKNOWN
+    #    ttype = fmpz_set_any_ref(tval, other)
+    #    if ttype == FMPZ_UNKNOWN:
+    #        return NotImplemented
+    #    u = fmpz.__new__(fmpz)
+    #    fmpz_or((<fmpz>u).val, self.val, tval)
+    #    if ttype == FMPZ_TMP:
+    #        fmpz_clear(tval)
+    #    return u
+    #
+    #def __ror__(self, other):
+    #    cdef fmpz_struct tval[1]
+    #    cdef int ttype = FMPZ_UNKNOWN
+    #    ttype = fmpz_set_any_ref(tval, other)
+    #    if ttype == FMPZ_UNKNOWN:
+    #        return NotImplemented
+    #    u = fmpz.__new__(fmpz)
+    #    fmpz_or((<fmpz>u).val, tval, self.val)
+    #    if ttype == FMPZ_TMP:
+    #        fmpz_clear(tval)
+    #    return u
+
     def __or__(self, other):
-        cdef fmpz_struct tval[1]
-        cdef int ttype = FMPZ_UNKNOWN
-        ttype = fmpz_set_any_ref(tval, other)
-        if ttype == FMPZ_UNKNOWN:
+        if typecheck(other, fmpz):
+            other = int(other)
+        if typecheck(other, int):
+            return fmpz(int(self) | other)
+        else:
             return NotImplemented
-        u = fmpz.__new__(fmpz)
-        fmpz_or((<fmpz>u).val, self.val, tval)
-        if ttype == FMPZ_TMP:
-            fmpz_clear(tval)
-        return u
 
     def __ror__(self, other):
-        cdef fmpz_struct tval[1]
-        cdef int ttype = FMPZ_UNKNOWN
-        ttype = fmpz_set_any_ref(tval, other)
-        if ttype == FMPZ_UNKNOWN:
+        if typecheck(other, int):
+            return fmpz(other | int(self))
+        else:
             return NotImplemented
-        u = fmpz.__new__(fmpz)
-        fmpz_or((<fmpz>u).val, tval, self.val)
-        if ttype == FMPZ_TMP:
-            fmpz_clear(tval)
-        return u
 
     def __xor__(self, other):
         cdef fmpz_struct tval[1]

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -369,7 +369,7 @@ cdef class fmpz(flint_scalar):
 
             if not success:
                 if ttype == FMPZ_TMP: fmpz_clear(tval)
-                raise ValueError("fmpz_pow_fmpz: exponent too large")
+                raise OverflowError("fmpz_pow_fmpz: exponent too large")
         else:
             # Modular exponentiation
             mtype = fmpz_set_any_ref(mval, m)
@@ -406,6 +406,8 @@ cdef class fmpz(flint_scalar):
         if typecheck(other, fmpz):
             other = int(other)
         if typecheck(other, int):
+            if other < 0:
+                raise ValueError("negative shift count")
             u = fmpz.__new__(fmpz)
             fmpz_mul_2exp((<fmpz>u).val, self.val, other)
             return u
@@ -413,9 +415,12 @@ cdef class fmpz(flint_scalar):
             return NotImplemented
 
     def __rlshift__(self, other):
+        iself = int(self)
+        if iself < 0:
+            raise ValueError("negative shift count")
         if typecheck(other, int):
             u = fmpz.__new__(fmpz)
-            fmpz_mul_2exp((<fmpz>u).val, fmpz(other).val, int(self))
+            fmpz_mul_2exp((<fmpz>u).val, fmpz(other).val, iself)
             return u
         else:
             return NotImplemented
@@ -424,6 +429,8 @@ cdef class fmpz(flint_scalar):
         if typecheck(other, fmpz):
             other = int(other)
         if typecheck(other, int):
+            if other < 0:
+                raise ValueError("negative shift count")
             u = fmpz.__new__(fmpz)
             fmpz_fdiv_q_2exp((<fmpz>u).val, self.val, other)
             return u
@@ -431,9 +438,12 @@ cdef class fmpz(flint_scalar):
             return NotImplemented
 
     def __rrshift__(self, other):
+        iself = int(self)
+        if iself < 0:
+            raise ValueError("negative shift count")
         if typecheck(other, int):
             u = fmpz.__new__(fmpz)
-            fmpz_fdiv_q_2exp((<fmpz>u).val, fmpz(other).val, int(self))
+            fmpz_fdiv_q_2exp((<fmpz>u).val, fmpz(other).val, iself)
             return u
         else:
             return NotImplemented

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -91,6 +91,14 @@ cdef class fmpz(flint_scalar):
                         return
                     raise TypeError("cannot create fmpz from type %s" % type(val))
 
+    @property
+    def numerator(self):
+        return self
+
+    @property
+    def denominator(self):
+        return fmpz(1)
+
     # XXX: improve!
     def __int__(self):
         return fmpz_get_intlong(self.val)
@@ -100,6 +108,9 @@ cdef class fmpz(flint_scalar):
 
     def __index__(self):
         return fmpz_get_intlong(self.val)
+
+    def __float__(self):
+        return float(fmpz_get_intlong(self.val))
 
     def __richcmp__(s, t, int op):
         cdef bint res = 0
@@ -334,28 +345,171 @@ cdef class fmpz(flint_scalar):
         return u
 
     def __pow__(s, t, m):
-        cdef ulong exp
+        cdef fmpz_struct tval[1]
+        cdef fmpz_struct mval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        cdef int mtype = FMPZ_UNKNOWN
+        cdef int success
         u = NotImplemented
-        if m is not None:
-            raise NotImplementedError("modular exponentiation")
-        c = t
-        u = fmpz.__new__(fmpz)
-        fmpz_pow_ui((<fmpz>u).val, (<fmpz>s).val, c)
+        ttype = fmpz_set_any_ref(tval, t)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+
+        if m is None:
+            # fmpz_pow_fmpz throws if x is negative
+            if fmpz_sgn(tval) == -1:
+                if ttype == FMPZ_TMP: fmpz_clear(tval)
+                raise ValueError("negative exponent")
+
+            u = fmpz.__new__(fmpz)
+            success = fmpz_pow_fmpz((<fmpz>u).val, (<fmpz>s).val, tval)
+
+            if not success:
+                if ttype == FMPZ_TMP: fmpz_clear(tval)
+                raise ValueError("fmpz_pow_fmpz: exponent too large")
+        else:
+            # Modular exponentiation
+            mtype = fmpz_set_any_ref(mval, m)
+            if mtype != FMPZ_UNKNOWN:
+
+                if fmpz_is_zero(mval):
+                    if ttype == FMPZ_TMP: fmpz_clear(tval)
+                    if mtype == FMPZ_TMP: fmpz_clear(mval)
+                    raise ValueError("pow(): modulus cannot be zero")
+
+                # The Flint docs say that fmpz_powm will throw if m is zero
+                # but it also throws if m is negative. Python generally allows
+                # e.g. pow(2, 2, -3) == (2^2) % (-3) == -2. We could implement
+                # that here as well but it is not clear how useful it is.
+                if fmpz_sgn(mval) == -1:
+                    if ttype == FMPZ_TMP: fmpz_clear(tval)
+                    if mtype == FMPZ_TMP: fmpz_clear(mval)
+                    raise ValueError("pow(): negative modulua not supported")
+
+                u = fmpz.__new__(fmpz)
+                fmpz_powm((<fmpz>u).val, (<fmpz>s).val, tval, mval)
+
+        if ttype == FMPZ_TMP: fmpz_clear(tval)
+        if mtype == FMPZ_TMP: fmpz_clear(mval)
         return u
 
     def __rpow__(s, t, m):
-        cdef fmpz_struct tval[1]
-        cdef int stype = FMPZ_UNKNOWN
-        cdef ulong exp
-        u = NotImplemented
-        if m is not None:
-            raise NotImplementedError("modular exponentiation")
-        ttype = fmpz_set_any_ref(tval, t)
-        if ttype != FMPZ_UNKNOWN:
+        t = any_as_fmpz(t)
+        if t is NotImplemented:
+            return t
+        return t.__pow__(s, m)
+
+    def __lshift__(self, other):
+        if typecheck(other, fmpz):
+            other = int(other)
+        if typecheck(other, int):
             u = fmpz.__new__(fmpz)
-            s_ulong = fmpz_get_ui(s.val)
-            fmpz_pow_ui((<fmpz>u).val, tval, s_ulong)
-        if ttype == FMPZ_TMP: fmpz_clear(tval)
+            fmpz_mul_2exp((<fmpz>u).val, self.val, other)
+            return u
+        else:
+            return NotImplemented
+
+    def __rlshift__(self, other):
+        if typecheck(other, int):
+            u = fmpz.__new__(fmpz)
+            fmpz_mul_2exp((<fmpz>u).val, fmpz(other).val, int(self))
+            return u
+        else:
+            return NotImplemented
+
+    def __rshift__(self, other):
+        if typecheck(other, fmpz):
+            other = int(other)
+        if typecheck(other, int):
+            u = fmpz.__new__(fmpz)
+            fmpz_fdiv_q_2exp((<fmpz>u).val, self.val, other)
+            return u
+        else:
+            return NotImplemented
+
+    def __rrshift__(self, other):
+        if typecheck(other, int):
+            u = fmpz.__new__(fmpz)
+            fmpz_fdiv_q_2exp((<fmpz>u).val, fmpz(other).val, int(self))
+            return u
+        else:
+            return NotImplemented
+
+    def __and__(self, other):
+        cdef fmpz_struct tval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        ttype = fmpz_set_any_ref(tval, other)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+        u = fmpz.__new__(fmpz)
+        fmpz_and((<fmpz>u).val, self.val, tval)
+        if ttype == FMPZ_TMP:
+            fmpz_clear(tval)
+        return u
+
+    def __rand__(self, other):
+        cdef fmpz_struct tval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        ttype = fmpz_set_any_ref(tval, other)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+        u = fmpz.__new__(fmpz)
+        fmpz_and((<fmpz>u).val, tval, self.val)
+        if ttype == FMPZ_TMP:
+            fmpz_clear(tval)
+        return u
+
+    def __or__(self, other):
+        cdef fmpz_struct tval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        ttype = fmpz_set_any_ref(tval, other)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+        u = fmpz.__new__(fmpz)
+        fmpz_or((<fmpz>u).val, self.val, tval)
+        if ttype == FMPZ_TMP:
+            fmpz_clear(tval)
+        return u
+
+    def __ror__(self, other):
+        cdef fmpz_struct tval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        ttype = fmpz_set_any_ref(tval, other)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+        u = fmpz.__new__(fmpz)
+        fmpz_or((<fmpz>u).val, tval, self.val)
+        if ttype == FMPZ_TMP:
+            fmpz_clear(tval)
+        return u
+
+    def __xor__(self, other):
+        cdef fmpz_struct tval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        ttype = fmpz_set_any_ref(tval, other)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+        u = fmpz.__new__(fmpz)
+        fmpz_xor((<fmpz>u).val, self.val, tval)
+        if ttype == FMPZ_TMP:
+            fmpz_clear(tval)
+        return u
+
+    def __rxor__(self, other):
+        cdef fmpz_struct tval[1]
+        cdef int ttype = FMPZ_UNKNOWN
+        ttype = fmpz_set_any_ref(tval, other)
+        if ttype == FMPZ_UNKNOWN:
+            return NotImplemented
+        u = fmpz.__new__(fmpz)
+        fmpz_xor((<fmpz>u).val, tval, self.val)
+        if ttype == FMPZ_TMP:
+            fmpz_clear(tval)
+        return u
+
+    def __invert__(self):
+        u = fmpz.__new__(fmpz)
+        fmpz_complement((<fmpz>u).val, self.val)
         return u
 
     def gcd(self, other):

--- a/src/flint/fmpz.pyx
+++ b/src/flint/fmpz.pyx
@@ -99,6 +99,9 @@ cdef class fmpz(flint_scalar):
     def denominator(self):
         return fmpz(1)
 
+    def __reduce__(self):
+        return (fmpz, (int(self),))
+
     # XXX: improve!
     def __int__(self):
         return fmpz_get_intlong(self.val)

--- a/test/test.py
+++ b/test/test.py
@@ -85,23 +85,22 @@ def test_fmpz():
         for t in L:
             for ltype in (flint.fmpz, int, long):
                 for rtype in (flint.fmpz, int, long):
+
+                    assert (ltype(s) == rtype(t)) == (s == t)
+                    assert (ltype(s) != rtype(t)) == (s != t)
+                    assert (ltype(s) < rtype(t)) == (s < t)
+                    assert (ltype(s) <= rtype(t)) == (s <= t)
+                    assert (ltype(s) > rtype(t)) == (s > t)
+                    assert (ltype(s) >= rtype(t)) == (s >= t)
+
                     assert ltype(s) + rtype(t) == s + t
                     assert ltype(s) - rtype(t) == s - t
                     assert ltype(s) * rtype(t) == s * t
                     assert ltype(s) & rtype(t) == s & t
+                    assert ltype(s) | rtype(t) == s | t
+                    assert ltype(s) ^ rtype(t) == s ^ t
                     assert ~ltype(s) == ~s
 
-                    # XXX: Some sort of bug here means that the following fails
-                    # for values of s and t bigger than the word size.
-                    if abs(s) < 2**62 and abs(t) < 2**62:
-                        assert ltype(s) | rtype(t) == s | t
-                    else:
-                        # This still works so somehow the internal representation
-                        # of the fmpz made by fmpz_or is such that fmpz_equal
-                        # returns false even though the values look the same.
-                        assert str(ltype(s) | rtype(t)) == str(s | t)
-
-                    assert ltype(s) ^ rtype(t) == s ^ t
                     if t == 0:
                         assert raises(lambda: ltype(s) // rtype(t), ZeroDivisionError)
                         assert raises(lambda: ltype(s) % rtype(t), ZeroDivisionError)
@@ -110,12 +109,7 @@ def test_fmpz():
                         assert ltype(s) // rtype(t) == s // t
                         assert ltype(s) % rtype(t) == s % t
                         assert divmod(ltype(s), rtype(t)) == divmod(s, t)
-                    assert (ltype(s) == rtype(t)) == (s == t)
-                    assert (ltype(s) != rtype(t)) == (s != t)
-                    assert (ltype(s) < rtype(t)) == (s < t)
-                    assert (ltype(s) <= rtype(t)) == (s <= t)
-                    assert (ltype(s) > rtype(t)) == (s > t)
-                    assert (ltype(s) >= rtype(t)) == (s >= t)
+
                     if 0 <= t < 10:
                         assert (ltype(s) ** rtype(t)) == (s ** t)
                         assert ltype(s) << rtype(t) == s << t

--- a/test/test.py
+++ b/test/test.py
@@ -161,6 +161,18 @@ def test_fmpz():
     assert type(operator.index(f)) is int
     assert float(f) == 2.0
     assert type(float(f)) is float
+    assert round(f) == 2
+    assert type(round(f)) is flint.fmpz
+    assert round(f, 1) == 2
+    assert type(round(f, 1)) is flint.fmpz
+    assert round(f, -1) == 0
+    assert type(round(f, -1)) is flint.fmpz
+    assert math.trunc(f) == 2
+    assert type(math.trunc(f)) is flint.fmpz
+    assert math.floor(f) == 2
+    assert type(math.floor(f)) is flint.fmpz
+    assert math.ceil(f) == 2
+    assert type(math.ceil(f)) is flint.fmpz
 
     assert flint.fmpz(2) != []
     assert +flint.fmpz(0) == 0
@@ -811,11 +823,20 @@ def test_fmpq():
     assert Q(5,3).ceil() == flint.fmpz(2)
     assert Q(-5,3).ceil() == flint.fmpz(-1)
 
-    assert int(Q(5,3)) == flint.fmpz(1)
+    assert type(int(Q(5,3))) is int
+    assert type(math.floor(Q(5,3))) is flint.fmpz
+    assert type(math.ceil(Q(5,3))) is flint.fmpz
+    assert type(math.trunc(Q(5,3))) is flint.fmpz
+    assert type(round(Q(5,3))) is flint.fmpz
+    assert type(round(Q(5,3))) is flint.fmpz
+    assert type(round(Q(5,3), 0)) is flint.fmpq
+    assert type(round(Q(5,3), 1)) is flint.fmpq
+
+    assert int(Q(5,3)) == 1
     assert math.floor(Q(5,3)) == flint.fmpz(1)
     assert math.ceil(Q(5,3)) == flint.fmpz(2)
     assert math.trunc(Q(5,3)) == flint.fmpz(1)
-    assert round(Q(5,3)) == 2
+    assert round(Q(5,3)) == flint.fmpz(2)
 
     assert int(Q(-5,3)) == flint.fmpz(-1)
     assert math.floor(Q(-5,3)) == flint.fmpz(-2)
@@ -823,9 +844,6 @@ def test_fmpq():
     assert math.trunc(Q(-5,3)) == flint.fmpz(-1)
     assert round(Q(-5,3)) == -2
 
-    assert type(round(Q(5,3))) is flint.fmpz
-    assert type(round(Q(5,3), 0)) is flint.fmpq
-    assert type(round(Q(5,3), 1)) is flint.fmpq
     assert round(Q(100,3), 2) == Q(3333,100)
     assert round(Q(100,3), 0) == Q(33,1)
     assert round(Q(100,3), -1) == Q(30,1)

--- a/test/test.py
+++ b/test/test.py
@@ -101,6 +101,23 @@ def test_fmpz():
                     assert (ltype(s) >= rtype(t)) == (s >= t)
                     if 0 <= t < 10:
                         assert (ltype(s) ** rtype(t)) == (s ** t)
+
+    pow_mod_examples = [
+        (2, 2, 3, 1),
+        (2, -1, 5, 3),
+        (2, 0, 5, 1),
+    ]
+    for a, b, c, ab_mod_c in pow_mod_examples:
+        assert pow(a, b, c) == ab_mod_c
+        assert pow(flint.fmpz(a), b, c) == ab_mod_c
+        assert pow(a, flint.fmpz(b), c) == ab_mod_c
+        assert pow(flint.fmpz(a), flint.fmpz(b), c) == ab_mod_c
+        assert pow(flint.fmpz(a), flint.fmpz(b), flint.fmpz(c)) == ab_mod_c
+
+    assert raises(lambda: pow(flint.fmpz(2), 2, 0), ValueError)
+    # XXX: Handle negative modulus like int?
+    assert raises(lambda: pow(flint.fmpz(2), 2, -1), ValueError)
+
     assert flint.fmpz(2) != []
     assert +flint.fmpz(0) == 0
     assert +flint.fmpz(1) == 1
@@ -139,7 +156,6 @@ def test_fmpz():
     big = flint.fmpz(bigstr)
     assert big.str() == bigstr
     assert big.str(condense=10) == '1111111111{...80 digits...}1111111111'
-    assert raises(lambda: pow(flint.fmpz(2), 2, 3), NotImplementedError)
 
 def test_fmpz_factor():
     assert flint.fmpz(6).gcd(flint.fmpz(9)) == 3


### PR DESCRIPTION
This is a companion to the SymPy PR adding flint for ground types:

https://github.com/sympy/sympy/pull/25474

Various things are added:

- `numerator/denominator` for `fmpz` and `fmpq`.
- `__int__` and `__floor__` methods.
- bitwise operators `&` etc for `fmpz`
- modular exponentiation `pow(a, b, c)` for `fmpz`.
- `fmpq ** fmpz`.